### PR TITLE
fix(renovate): detect linuxserver image versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,5 +23,12 @@
   },
   "pre-commit": {
     "enabled": true
-  }
+  },
+  "packageRules": [
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["lscr.io/linuxserver/**"],
+      "versioning": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(\\.(?<build>\\d+))?(-ls(?<revision>\\d+))?$"
+    }
+  ]
 }


### PR DESCRIPTION
Linuxserver images use a 4-segment + `-ls<build>` tag format (e.g.
`4.0.17.2952-ls305`) that Renovate's default semver versioning cannot
parse, so updates for radarr, sonarr, lidarr, prowlarr, bazarr, and
tautulli were being skipped. Add a packageRule with a regex versioning
scheme so Renovate can compare these tags and propose updates.