### PR TITLE
chore(deps): pin floating tags so Renovate can track updates

### DIFF
--- a/manifests/kube-system/multus-cni/daemonset.yaml
+++ b/manifests/kube-system/multus-cni/daemonset.yaml
@@ -18,7 +18,7 @@ spec:
         - operator: Exists
       initContainers:
         - name: bridge-vlan-setup
-          image: nicolaka/netshoot:latest
+          image: nicolaka/netshoot:v0.15
           command:
             - /bin/sh
             - -c
@@ -44,7 +44,7 @@ spec:
               mountPath: /host
       containers:
         - name: pause
-          image: gcr.io/google_containers/pause:3.2
+          image: registry.k8s.io/pause:3.10.2
       volumes:
         - name: host
           hostPath:

--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,27 @@
       "matchDatasources": ["docker"],
       "matchPackageNames": ["lscr.io/linuxserver/**"],
       "versioning": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(\\.(?<build>\\d+))?(-ls(?<revision>\\d+))?$"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["ghcr.io/thephaseless/byparr"],
+      "extractVersion": "^v?(?<version>.+)$"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["nicolaka/netshoot"],
+      "replacementVersion": "v0.15"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["docker.io/envoyproxy/ratelimit"],
+      "replacementVersion": "v1.4.0"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["gcr.io/google_containers/pause"],
+      "replacementName": "registry.k8s.io/pause",
+      "replacementVersion": "3.10.2"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -29,27 +29,6 @@
       "matchDatasources": ["docker"],
       "matchPackageNames": ["lscr.io/linuxserver/**"],
       "versioning": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(\\.(?<build>\\d+))?(-ls(?<revision>\\d+))?$"
-    },
-    {
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["ghcr.io/thephaseless/byparr"],
-      "extractVersion": "^v?(?<version>.+)$"
-    },
-    {
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["nicolaka/netshoot"],
-      "replacementVersion": "v0.15"
-    },
-    {
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["docker.io/envoyproxy/ratelimit"],
-      "replacementVersion": "v1.4.0"
-    },
-    {
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["gcr.io/google_containers/pause"],
-      "replacementName": "registry.k8s.io/pause",
-      "replacementVersion": "3.10.2"
     }
   ]
 }

--- a/values/envoy-gateway/envoy-gateway/base/values.yaml
+++ b/values/envoy-gateway/envoy-gateway/base/values.yaml
@@ -19,7 +19,7 @@ config:
                     containers:
                       - imagePullPolicy: IfNotPresent
                         name: envoy-ratelimit
-                        image: docker.io/envoyproxy/ratelimit:60d8e81b
+                        image: docker.io/envoyproxy/ratelimit:v1.4.0
     rateLimit:
       backend:
         type: Redis

--- a/values/media-management/flaresolverr/base/values.yaml
+++ b/values/media-management/flaresolverr/base/values.yaml
@@ -4,7 +4,7 @@ controllers:
       app:
         image:
           repository: ghcr.io/thephaseless/byparr
-          tag: 2.1.0
+          tag: v2.1.2
         env:
           LOG_LEVEL: info
           LOG_HTML: "false"


### PR DESCRIPTION
## Summary
Fix the actual source files instead of carrying static mappings in `renovate.json`. Once the pinned tags are in a format Renovate can compare, default semver tracking handles ongoing updates.

| File | Change | Why |
|---|---|---|
| `values/media-management/flaresolverr/base/values.yaml` | byparr `2.1.0` → `v2.1.2` | Match upstream's `v`-prefixed tag scheme so Renovate's semver tracking picks up new releases |
| `manifests/kube-system/multus-cni/daemonset.yaml` | netshoot `:latest` → `v0.15` | Explicit pin makes the image trackable |
| `manifests/kube-system/multus-cni/daemonset.yaml` | `gcr.io/google_containers/pause:3.2` → `registry.k8s.io/pause:3.10.2` | New tags are no longer published to the deprecated `gcr.io/google_containers` registry |
| `values/envoy-gateway/envoy-gateway/base/values.yaml` | ratelimit SHA `60d8e81b` → `v1.4.0` | SHA tags are opaque to Renovate; switch to the semver release |

The `lscr.io/linuxserver/**` regex versioning rule in `renovate.json` stays — it's a real configuration rule, not a static mapping.

## Test plan
- [ ] ArgoCD reconciles the multus-cni DaemonSet (pause container restarts on new image)
- [ ] flaresolverr pod comes up on `v2.1.2`
- [ ] envoy-gateway ratelimit deployment rolls out on `v1.4.0`
- [ ] Renovate's next scan no longer flags these as untracked on the Dependency Dashboard (issue #2)

https://claude.ai/code/session_01TTxE5XUpmE3jGfkXzQ3mXK