### PR TITLE
Enable automerge for minor and patch dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,11 @@
       "matchDatasources": ["docker"],
       "matchPackageNames": ["lscr.io/linuxserver/**"],
       "versioning": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(\\.(?<build>\\d+))?(-ls(?<revision>\\d+))?$"
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "platformAutomerge": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
Added a new Renovate configuration rule to automatically merge minor and patch version updates across all dependencies.

## Changes
- Added a new configuration object to the `extends` array in `renovate.json` that:
  - Targets minor and patch version updates via `matchUpdateTypes`
  - Enables automerge functionality with both `automerge` and `platformAutomerge` flags set to true
  - Applies to all dependencies not covered by more specific rules

## Details
This configuration allows Renovate to automatically merge non-breaking dependency updates (minor and patch versions) without requiring manual approval, streamlining the dependency update process while maintaining stability by excluding major version changes.

https://claude.ai/code/session_01NxRQXdEqNbJQ58NgWkWEQQ