### PR TITLE
Renovate: auto-merge minor/patch + stability, schedule, grouping, custom managers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,18 @@
   "extends": [
     "config:recommended"
   ],
+  "minimumReleaseAge": "1 day",
+  "schedule": [
+    "after 10pm every weekday",
+    "before 5am every weekday",
+    "every weekend"
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"],
+    "minimumReleaseAge": null,
+    "schedule": ["at any time"]
+  },
   "prHourlyLimit": 0,
   "argocd": {
     "managerFilePatterns": [
@@ -24,6 +36,19 @@
   "pre-commit": {
     "enabled": true
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^applications/.+\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "repoURL:\\s*(?<depName>https://github\\.com/[\\w./-]+?)(?:\\.git)?\\s+targetRevision:\\s*\"?(?<currentValue>v?\\d+\\.\\d+\\.\\d+[\\w.-]*)\"?"
+      ],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver"
+    }
+  ],
   "packageRules": [
     {
       "matchDatasources": ["docker"],
@@ -31,7 +56,17 @@
       "versioning": "regex:^v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(\\.(?<build>\\d+))?(-ls(?<revision>\\d+))?$"
     },
     {
-      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "*arr media stack",
+      "matchPackageNames": [
+        "lscr.io/linuxserver/radarr",
+        "lscr.io/linuxserver/sonarr",
+        "lscr.io/linuxserver/lidarr",
+        "lscr.io/linuxserver/bazarr",
+        "lscr.io/linuxserver/prowlarr"
+      ]
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch", "digest", "pin", "pinDigest"],
       "automerge": true,
       "platformAutomerge": true
     }

--- a/renovate.json
+++ b/renovate.json
@@ -47,6 +47,17 @@
       ],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^manifests/.+\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "https://github\\.com/(?<depName>[\\w.-]+/[\\w.-]+)/releases/download/(?<currentValue>[^/\\s]+)/"
+      ],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
## Summary
- Auto-merge `minor`, `patch`, `digest`, `pin`, and `pinDigest` updates via GitHub platform automerge; major bumps still require manual review.
- 1-day stability window (`minimumReleaseAge`) so upstream regressions surface before a PR opens; vulnerability alerts bypass the window and the schedule.
- Off-hours schedule (nights + weekends, UTC) to keep PR/CI churn out of the workday.
- Group the *arr media stack (Radarr/Sonarr/Lidarr/Bazarr/Prowlarr) into a single PR per release wave.
- Custom regex managers:
  - ArgoCD git-source `targetRevision` pinned to semver tags in `applications/**` (no current targets — future-proofs git-pinned sources).
  - GitHub release-asset URLs in `manifests/**`, so `kubevirt/kubevirt` (`v1.7.1`) and `kubevirt/containerized-data-importer` (`v1.64.0`) versions get tracked.
- `metrics-server` uses `/releases/latest/download/` and remains untracked — pin it to a tag if you want Renovate to manage it.

## Test plan
- [ ] Confirm Renovate's next dry-run / dashboard issue lists kubevirt + CDI as new tracked deps.
- [ ] Verify branch protection on `main` has at least one required status check so GitHub platform automerge is actually available; otherwise Renovate falls back to merging itself once checks pass.
- [ ] Watch the first minor/patch PR to confirm it auto-merges after CI.
- [ ] Watch the first *arr update wave to confirm a single grouped PR is opened.

https://claude.ai/code/session_01NxRQXdEqNbJQ58NgWkWEQQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxRQXdEqNbJQ58NgWkWEQQ)_