### PR TITLE
fix(rook-ceph): drop failed osd disk on blade-243; bump replicapool to size=3

### DIFF
--- a/manifests/rook-ceph/rook-ceph/cephblockpool-ssd.yaml
+++ b/manifests/rook-ceph/rook-ceph/cephblockpool-ssd.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   failureDomain: host
   replicated:
-    size: 2
+    size: 3
     requireSafeReplicaSize: true
   parameters:
     pg_autoscale_mode: 'on'

--- a/manifests/rook-ceph/rook-ceph/cluster.yaml
+++ b/manifests/rook-ceph/rook-ceph/cluster.yaml
@@ -280,7 +280,8 @@ spec:
       - name: blade-243
         devices:
           - name: "/dev/disk/by-id/wwn-0x50011731004267bc"
-          - name: "/dev/disk/by-id/wwn-0x5001173100427674"
+          # wwn-0x5001173100427674 removed: drive wedged the kernel block layer
+          # (bdev_open / blkid hang in D-state, survives reboot). Replace HW.
           - name: "/dev/disk/by-id/wwn-0x50011731004276b0"
           - name: "/dev/nvme0n1"
             config:


### PR DESCRIPTION
## Summary
- Remove `wwn-0x5001173100427674` from blade-243's device list. The SanDisk DOPE0480 at this WWN deadlocks the kernel block layer — `bdev_open` and `blkid` hang in D-state, surviving even SIGKILL. A Talos reboot did not clear it. OSD-8 has already been purged live (`ceph osd lost 8` + `ceph osd purge 8` + `kubectl delete deploy rook-ceph-osd-8`); this commit prevents the next osd-prepare run from re-provisioning the dead disk.
- Bump `replicapool` from `size=2` to `size=3`. With `size=2 min_size=1`, one OSD failure took 3 RBD PGs inactive (`pg 2.b`, `2.4b`, `2.8b` — all primary on osd.14 with osd.8 as the only peer). 4 storage hosts give plenty of room for `size=3`, which keeps RBD available across a single OSD or host failure. `min_size` is auto-derived to 2 by Rook.

## Context
Today's incident: `ceph-volume raw activate` for OSDs 2/3/8/9/14 wedged in D-state after the rook-ceph 1.19.4 → 1.19.5 chart bump triggered a deployment refresh. blade-244's OSDs (2/3) self-healed once their stale `ROOK_BLOCK_PATH` env was rewritten by a successful prepare run. blade-243 needed a reboot, which recovered OSDs 9 and 14 but **not** OSD-8 — its disk's open()s now block in `bdev_open` independent of any userspace holder, pointing at a controller-level firmware wedge.

Cluster is currently `HEALTH_WARN` only because of the pre-existing `pg_num > pgp_num` advisory on replicapool; backfill from the OSD-8 purge is in progress (~1.3 GiB/s).

## Test plan
- [ ] ArgoCD shows the rook-ceph app diff matches this commit
- [ ] Sync rook-ceph; confirm `kubectl get cephblockpool replicapool -o yaml | grep size` shows `size: 3`
- [ ] Confirm next osd-prepare run on blade-243 logs no attempt to inventory the removed WWN
- [ ] `ceph -s` ends up `HEALTH_OK` (or only `SMALLER_PGP_NUM`) after backfill drains
- [ ] Replace the dead drive (`wwn-0x5001173100427674`) physically when convenient; re-add to cluster.yaml after replacement

🤖 Generated with [Claude Code](https://claude.com/claude-code)